### PR TITLE
Fixed broken link in request-data.js

### DIFF
--- a/scripts/request-data.js
+++ b/scripts/request-data.js
@@ -3,7 +3,7 @@ const MyContract = artifacts.require('MyContract')
 /*
   This script allows for a Chainlink request to be created from
   the requesting contract. Defaults to the Chainlink oracle address
-  on this page: https://docs.chain.link/docs/testnet-oracles
+  on this page: https://docs.chain.link/docs/decentralized-oracles-ethereum-mainnet/#testnets
 */
 
 const oracleAddress =


### PR DESCRIPTION
Fixed broken link on `request-data.js` script. 
Pretty similar issue flagged in #98.
